### PR TITLE
Add French/English localization

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,38 @@
+{
+  "extensionName": {
+    "message": "Vision Aid: Image Magnifier"
+  },
+  "extensionDescription": {
+    "message": "Enlarge images on hover for better accessibility. Perfect for visually impaired users."
+  },
+  "actionPopupTitle": {
+    "message": "Vision Aid Options"
+  },
+  "headingMain": {
+    "message": "Vision Aid Magnifier"
+  },
+  "descriptionMain": {
+    "message": "Hover over an image or link to an image to enlarge it instantly."
+  },
+  "labelEnableExtension": {
+    "message": "Enable extension"
+  },
+  "sectionZoomTitle": {
+    "message": "Magnification mode"
+  },
+  "radioNaturalLabel": {
+    "message": "Double size (side)"
+  },
+  "radioPageLabel": {
+    "message": "Full width (overlay)"
+  },
+  "footerCreatedBy": {
+    "message": "Created by <strong>Miroum</strong>"
+  },
+  "footerGithubLink": {
+    "message": "See the project on GitHub"
+  },
+  "footerInspiredBy": {
+    "message": "Inspired by"
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,38 @@
+{
+  "extensionName": {
+    "message": "Vision Aid: Image Magnifier"
+  },
+  "extensionDescription": {
+    "message": "Agrandit les images au survol pour une meilleure accessibilité. Parfait pour les utilisateurs ayant une déficience visuelle."
+  },
+  "actionPopupTitle": {
+    "message": "Options Vision Aid"
+  },
+  "headingMain": {
+    "message": "Vision Aid Magnifier"
+  },
+  "descriptionMain": {
+    "message": "Survolez une image ou un lien vers une image pour l'agrandir instantanément."
+  },
+  "labelEnableExtension": {
+    "message": "Activer l'extension"
+  },
+  "sectionZoomTitle": {
+    "message": "Mode d'agrandissement"
+  },
+  "radioNaturalLabel": {
+    "message": "Taille doublée (côté)"
+  },
+  "radioPageLabel": {
+    "message": "Pleine largeur (superposé)"
+  },
+  "footerCreatedBy": {
+    "message": "Créé par <strong>Miroum</strong>"
+  },
+  "footerGithubLink": {
+    "message": "Voir le projet sur GitHub"
+  },
+  "footerInspiredBy": {
+    "message": "Inspiré par"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Vision Aid: Image Magnifier",
+  "name": "__MSG_extensionName__",
   "version": "2.0.0",
-  "description": "Agrandit les images au survol pour une meilleure accessibilité. Parfait pour les utilisateurs ayant une déficience visuelle.",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "permissions": [
     "storage",      
     "scripting"     

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,22 +1,20 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html>
 <head>
     <meta charset="UTF-8">
-    <title>Options Vision Aid</title>
+    <title>__MSG_actionPopupTitle__</title>
     <link rel="stylesheet" href="popup.css">
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h1>Vision Aid Magnifier</h1>
-            <p class="description">
-                Survolez une image ou un lien vers une image pour l'agrandir instantanément.
-            </p>
+            <h1>__MSG_headingMain__</h1>
+            <p class="description">__MSG_descriptionMain__</p>
         </div>
 
         <div class="main-options">
             <div class="option">
-                <label for="toggle-extension" class="toggle-label">Activer l'extension</label>
+                <label for="toggle-extension" class="toggle-label">__MSG_labelEnableExtension__</label>
                 <label class="switch">
                     <input type="checkbox" id="toggle-extension">
                     <span class="slider"></span>
@@ -24,14 +22,14 @@
             </div>
             <hr>
             <div id="zoom-options" class="options-group">
-                <h2>Mode d'agrandissement</h2>
+                <h2>__MSG_sectionZoomTitle__</h2>
                 <div class="radio-option">
                     <input type="radio" id="zoom-natural" name="zoomMode" value="natural">
-                    <label for="zoom-natural">Taille doublée (côté)</label>
+                    <label for="zoom-natural">__MSG_radioNaturalLabel__</label>
                 </div>
                 <div class="radio-option">
                     <input type="radio" id="zoom-page" name="zoomMode" value="page">
-                    <label for="zoom-page">Pleine largeur (superposé)</label>
+                    <label for="zoom-page">__MSG_radioPageLabel__</label>
                 </div>
             </div>
         </div>
@@ -39,10 +37,10 @@
         <hr class="footer-separator">
 
         <footer>
-            <p>Créé par <strong>Miroum</strong></p>
-            <a href="https://github.com/Mir0um/Vision-Aid-Image-Magnifier" id="github-link">Voir le projet sur GitHub</a>
+            <p>__MSG_footerCreatedBy__</p>
+            <a href="https://github.com/Mir0um/Vision-Aid-Image-Magnifier" id="github-link">__MSG_footerGithubLink__</a>
 
-            <p class="inspiration">Inspiré par <a href="https://github.com/TheFantasticWarrior/chrome-extension-imagus" id="imagus-link">Imagus</a></p>
+            <p class="inspiration">__MSG_footerInspiredBy__ <a href="https://github.com/TheFantasticWarrior/chrome-extension-imagus" id="imagus-link">Imagus</a></p>
         </footer>
     </div>
     <script src="popup.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Set page language to match browser UI
     document.documentElement.lang = chrome.i18n.getUILanguage();
+
+    // Replace __MSG_***__ placeholders with translations
+    localizeHtml();
     // --- SÉLECTEURS ---
     const toggleSwitch = document.getElementById('toggle-extension');
     const zoomOptionsDiv = document.getElementById('zoom-options');
@@ -59,3 +62,24 @@ document.addEventListener('DOMContentLoaded', () => {
     githubLink.addEventListener('click', handleExternalLink);
     imagusLink.addEventListener('click', handleExternalLink); // NOUVEAU
 });
+
+// Replace all __MSG_key__ tokens in the DOM with localized strings
+function localizeHtml() {
+    const tokenRegex = /__MSG_(\w+)__/g;
+
+    // Replace text nodes
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+        const node = walker.currentNode;
+        node.nodeValue = node.nodeValue.replace(tokenRegex, (_, key) => chrome.i18n.getMessage(key) || '');
+    }
+
+    // Replace attribute values
+    document.querySelectorAll('*').forEach(el => {
+        Array.from(el.attributes).forEach(attr => {
+            if (attr.value.includes('__MSG_')) {
+                attr.value = attr.value.replace(tokenRegex, (_, key) => chrome.i18n.getMessage(key) || '');
+            }
+        });
+    });
+}

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
+    // Set page language to match browser UI
+    document.documentElement.lang = chrome.i18n.getUILanguage();
     // --- SÉLECTEURS ---
     const toggleSwitch = document.getElementById('toggle-extension');
     const zoomOptionsDiv = document.getElementById('zoom-options');


### PR DESCRIPTION
## Summary
- add i18n folders with English and French translations
- localize manifest metadata and popup
- set language based on browser UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885d60ccfb48333a08f2f2a92ff1449