### PR TITLE
Add video autoplay support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Miroum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Une extension Chrome simple, légère et efficace conçue pour l'accessibilité.
 ## Fonctionnalités principales
 
 *   **Agrandissement au survol** : Pas besoin de cliquer, il suffit de passer la souris sur un élément pour l'activer.
-*   **Détection Intelligente** : Fonctionne sur les balises `<img>` standards ainsi que sur les liens `<a>` qui pointent directement vers un fichier image (`.jpg`, `.png`, `.gif`, etc.).
+*   **Détection Intelligente** : Fonctionne sur les balises `<img>` et `<video>` ainsi que sur les liens `<a>` pointant vers des fichiers image ou vidéo (formats courants comme `.jpg`, `.png`, `.gif`, `.mp4`, `.webm`, etc.).
+*   **Lecture automatique des vidéos** : Lorsqu'une vidéo est détectée, elle se lance automatiquement dans la fenêtre d'aperçu.
 *   **Deux Modes d'Affichage** :
     1.  **Taille Doublée (côté)** : Affiche l'image à 200% de sa taille originale dans une fenêtre à côté du curseur. La fenêtre se positionne intelligemment à droite ou à gauche pour ne jamais sortir de l'écran.
     2.  **Pleine Largeur (superposé)** : Affiche l'image en grand format, superposée au contenu de la page et occupant la largeur de la fenêtre.

--- a/core/zoom.css
+++ b/core/zoom.css
@@ -22,6 +22,15 @@
   border-radius: 5px;
   animation: zoomIn 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) both;
 }
+#image-zoom-overlay video {
+  width: 100%;
+  height: 100%;
+  max-width: 95vw;
+  max-height: 95vh;
+  object-fit: contain;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+  border-radius: 5px;
+}
 
 /* NOUVEAU: Le conteneur pour l'agrandissement à côté du curseur */
 #image-zoom-viewer {
@@ -39,6 +48,12 @@
 
 #image-zoom-viewer img {
   /* L'image sera affichée à 200% de sa taille naturelle si possible, sans dépasser la fenêtre */
+  width: 100%;
+  height: auto;
+  max-width: 90vw;
+  max-height: 90vh;
+}
+#image-zoom-viewer video {
   width: 100%;
   height: auto;
   max-width: 90vw;


### PR DESCRIPTION
## Summary
- add MIT license file
- extend recognized image formats and detect videos
- show videos in the zoom overlay/viewer and autoplay them
- update CSS for video elements
- document new capabilities in README

## Testing
- `node --check core/content.js`

------
https://chatgpt.com/codex/tasks/task_e_6885de721d908333bf72638738982485